### PR TITLE
Config.schema changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The following actions are supported:
 
 ## Configuration
 
-Copy the example configuration in [octopus.yaml.example](./octopus.yaml.example)
-to `/opt/stackstorm/configs/octopus.yaml` and edit as required. It must contain:
+Copy the example configuration in [octopusdeploy.yaml.example](./octopusdeploy.yaml.example)
+to `/opt/stackstorm/configs/octopusdeploy.yaml` and edit as required. It must contain:
 
 * `api_key` - an API key generated in Octopus for your user http://docs.octopusdeploy.com/display/OD/How+to+create+an+API+key 
 * `host` - the host name of your Octopus server e.g. octopus.mydomain.com

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ deployment automation system for .NET applications.
 
 ## Actions
 
-Currently, the following actions listed bellow are supported:
+The following actions are supported:
 
 ### Projects
 
@@ -30,10 +30,11 @@ Currently, the following actions listed bellow are supported:
 
 ## Configuration
 
-Update config.yaml to setup the connection to Octopus.
+Copy the example configuration in [octopus.yaml.example](./octopus.yaml.example)
+to `/opt/stackstorm/configs/octopus.yaml` and edit as required. It must contain:
 
 * `api_key` - an API key generated in Octopus for your user http://docs.octopusdeploy.com/display/OD/How+to+create+an+API+key 
 * `host` - the host name of your Octopus server e.g. octopus.mydomain.com
 * `port` - the port your API service is running on, 443 by default
 
-a tutorial on this pack https://stackstorm.com/2015/10/01/octopusdeploy-integration-with-stackstorm/
+Read this pack tutorial for more information: https://stackstorm.com/2015/10/01/octopusdeploy-integration-with-stackstorm/

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -11,6 +11,6 @@
     required: true
   port:
     description: "Server port to use"
-    type: "string"
+    type: "integer"
     required: true
     default: 443

--- a/octopusdeploy.yaml.example
+++ b/octopusdeploy.yaml.example
@@ -1,0 +1,4 @@
+---
+api_key: "CHANGEME"
+host: "octopus.mydomain.com"
+port: 443

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
   - deployment
   - continous deployment
   - continous integration
-version : 0.1.0
+version : 0.1.1
 author : Anthony Shaw
 email : anthony.shaw@dimensiondata.com


### PR DESCRIPTION
README: Language fix and notes on using `config.schema.yaml`

Added `octopusdeploy.yaml.example`

Config.schema.yaml change - switch to integer for port.

Minor pack version bump due to port change